### PR TITLE
Fixed www routing (e.g. if someone tried from safari) it wouldn't red…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,9 @@ const HttpsRedirect = ({ disabled, children }) => {
     window.location.href = window.location.href.replace(
       /^http(?!s)/,
       'https'
-    );
+    ).replace(
+        'www.',
+        '';
     return null;
   }
 


### PR DESCRIPTION
…irect to https

If someone types www.testwebsite.tv it won't route to https://testwebsite.tv , thus having this fix on client side is fixing this problem.